### PR TITLE
Include the latest @automattic/vip-go version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
   },
   "dependencies": {
-    "@automattic/vip-go": "^0.3.2",
+    "@automattic/vip-go": "^1.0.1",
     "@babel/cli": "7.5.5",
     "@babel/core": "7.5.5",
     "@babel/preset-env": "7.5.5"


### PR DESCRIPTION
Update the dependencies installed for including the latest version of the must use @automattic/vip-go package.