### PR TITLE
Adds a note about the cache-healthcheck

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ var express = require( 'express' );
 var app = express();
 const PORT = process.env.PORT || 3000;
 
-// Used by the monitoring system on VIP Go to verify the health of the app
+// Used by the monitoring system on VIP to verify the health of the app
 // Should return 200 when the app is healthy
 // https://docs.wpvip.com/technical-references/vip-platform/node-js/
 app.get( '/cache-healthcheck', function( req, res ) {

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,9 @@ var express = require( 'express' );
 var app = express();
 const PORT = process.env.PORT || 3000;
 
+// Used by the monitoring system on VIP Go to verify the health of the app
+// Should return 200 when the app is healthy
+// https://docs.wpvip.com/technical-references/vip-platform/node-js/
 app.get( '/cache-healthcheck', function( req, res ) {
 	res.sendStatus( 200 );
 } );


### PR DESCRIPTION
Since `/cache-healthcheck` isn't necessarily standard outside VIP, adding this note should help with some context about how it's used on the platform.