### PR TITLE
Fix missing ? in cache-healthcheck route

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const PORT = process.env.PORT || 3000;
 // Used by the monitoring system on VIP to verify the health of the app
 // Should return 200 when the app is healthy
 // https://docs.wpvip.com/technical-references/vip-platform/node-js/
-app.get( '/cache-healthcheck', function( req, res ) {
+app.get( '/cache-healthcheck?', function( req, res ) {
 	res.sendStatus( 200 );
 } );
 


### PR DESCRIPTION
We were missing a `?` in our `/cache-healthcheck` route. This fixes it.