### PR TITLE
DOCS-489 - hotlink Express in Readme to the Express documentation

### DIFF
--- a/examples/static/README.md
+++ b/examples/static/README.md
@@ -3,7 +3,7 @@
 This example is a modified version of the skeleton code,
 designed to demonstrate serving static files.
 
-This uses Express to handle most of the logic, making
+This uses [Express](https://expressjs.com/) to handle most of the logic, making
 it very simple to just drop HTML, JS, CSS, and supporting files
 into one or more directories and then serve them, provided they exist.
 


### PR DESCRIPTION
This adds a link to Express for folks unfamiliar with it

In the future, this README will also link to the upcoming How To article (serve static content with Node), once it's published