### PR TITLE
Remove `renovate.json`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
## Description

This PR removes `renovate.json` to disable to [Renovate](https://href.li/?https://www.whitesourcesoftware.com/free-developer-tools/renovate/) bot.

- [x] [Verify that Dependabot is enabled](https://github.com/Automattic/vip-go-node-skeleton/settings/security_analysis) for this repo.
- [x] If desired, [configure it for your needs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file). (Though the default settings are pretty good.)
- [x] Manually review and close any [existing Renovate PRs or issues](https://github.com/Automattic/vip-go-node-skeleton/issues?q=is%3Aopen+author%3Aapp%2Frenovate).
