### PR TITLE
Provide valid base URL to URL constructor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ const app = http.createServer( ( req, res ) => {
 	 * Extract the pathname, without any query parameters, from the request. This
 	 * allows us to implement routing based purely on the requested path.
 	 */
-	const { pathname } = new URL( req.url, req.headers.host );
+	const { pathname } = new URL( req.url, `http://${ req.headers.host }` );
 
 	/**
 	 * Handle health checks


### PR DESCRIPTION
My recent changes introduced an error, since `req.headers.host` by itself is not a valid URL (it is missing the protocol). This follows the example in the official Node.js docs for extracting the pathname from the request:

https://nodejs.org/api/http.html#messageurl